### PR TITLE
Add "roll up" view of a proc's history that shows only durations.

### DIFF
--- a/app/js/proc-detail-controller.js
+++ b/app/js/proc-detail-controller.js
@@ -1,0 +1,38 @@
+pmWebControllers.controller("ProcDetailCtrl", function($scope, $routeParams, $http, $timeout) {
+
+  var toHHMMSS = function(sec_num) {
+    var hours   = Math.floor(sec_num / 3600);
+    var minutes = Math.floor((sec_num - (hours * 3600)) / 60);
+    var seconds = sec_num - (hours * 3600) - (minutes * 60);
+
+    if (hours   < 10) {hours   = "0"+hours;}
+    if (minutes < 10) {minutes = "0"+minutes;}
+    if (seconds < 10) {seconds = "0"+seconds;}
+    var time    = hours+':'+minutes+':'+seconds;
+    return time;
+  }
+
+  var getHistory = function() {
+    $http.get('http://'+$routeParams.host+'/procs/'+$routeParams.procId+'/history').then(function(result){
+      var serverTime = result.data.serverTime;
+      $scope.history = []
+      for(var i=0; i<result.data.history.length; i++) {      
+        var millisecs = (i==result.data.history.length-1) ? (Date.parse(serverTime)-Date.parse(result.data.history[i].ts)) : (Date.parse(result.data.history[i+1].ts)-Date.parse(result.data.history[i].ts));
+        var cumulativeTime = toHHMMSS(millisecs/1000);
+        $scope.history.push({cumulativeTime: cumulativeTime, status:result.data.history[i].status})
+      }
+      $timeout(getHistory, 1000);
+    }).catch(function(result){
+      $scope.active = false;
+    });
+  }
+  getHistory();
+  
+  $scope.active = true;
+  $scope.host = $routeParams.host;
+  $scope.procId = $routeParams.procId;
+
+  $scope.cancel = function(host,procId) {
+    $http.delete("http://"+ host +"/procs/"+ procId).then(function(r) {console.log(r)});
+  }
+});

--- a/server.go
+++ b/server.go
@@ -1,9 +1,9 @@
 package main
 
 import (
-	"github.com/VividCortex/pm"
 	"flag"
 	"fmt"
+	"github.com/VividCortex/pm"
 	"math/rand"
 	"sync"
 	"time"
@@ -32,18 +32,14 @@ func SomeProcess() {
 		id := fmt.Sprint(pid)
 		mutex.Unlock()
 
-		/*
 		defer func() {
 			if r := recover(); r != nil {
 				fmt.Printf("pid [%s] cancelled\n", id)
 			}
 			wg.Done()
-		}()*/
+		}()
+		attributes := packValues()
 
-		// --- Generate a new, random map of attributes ---
-		attributes:=packValues();
-
-		// --- Start the Process ---
 		pm.Start(id, nil, &attributes)
 		defer pm.Done(id)
 
@@ -56,59 +52,52 @@ func SomeProcess() {
 
 }
 
-// --- Not Inclusive of Maximum --- 
-func randInt(min int , max int) int {
-        rand.Seed( time.Now().UTC().UnixNano())
-        return min + rand.Intn(max-min)
+func randInt(min int, max int) int {
+	rand.Seed(time.Now().UTC().UnixNano())
+	return min + rand.Intn(max-min)
 }
 
 func packValues() map[string]interface{} {
+	theMap := make(map[string]interface{})
 
-	// --- Initialization ---
-	theMap:=make(map[string]interface{})
-
-	// --- The 'bank' of values to pull from ---
-	taste := [] string{
-		"salty", 
-		"sweet", 
+	taste := []string{
+		"salty",
+		"sweet",
 		"sour",
 	}
-	color := [] string{
-		"red", 
-		"green", 
+	color := []string{
+		"red",
+		"green",
 		"blue",
 	}
-	temperature := [] string{
-		"hot", 
-		"medium", 
+	temperature := []string{
+		"hot",
+		"medium",
 		"cold",
 	}
-
 	numAttrs := randInt(1, 4)
-	for i:=0; i<numAttrs; i++ {
-		d1 := randInt(1,4)
-		d2 := randInt(0,3)
+	for i := 0; i < numAttrs; i++ {
+		d1 := randInt(1, 4)
+		d2 := randInt(0, 3)
 		switch d1 {
-			case 1: theMap["Taste"]=taste[d2]
-			case 2: theMap["Color"]=color[d2]
-			case 3: theMap["Temperature"]=temperature[d2]
+		case 1:
+			theMap["Taste"] = taste[d2]
+		case 2:
+			theMap["Color"] = color[d2]
+		case 3:
+			theMap["Temperature"] = temperature[d2]
 		}
 	}
 	return theMap
 }
 
 func main() {
-
-	// --- Command Line Parsing ---
 	port := flag.String("port", ":8081", "port string (ex. :8081)")
 	flag.Parse()
 
 	go pm.ListenAndServe(*port)
-
-	// --- Command Line Checking ---
 	fmt.Printf("Listening on localhost%s\n", *port)
 
-	// --- Creating a ProcList of size 'i' ---
 	for i := 0; i < 10; i++ {
 		SomeProcess()
 	}


### PR DESCRIPTION
VividCortex/pm provides a time history of the states that each process has entered along with the times that the process entered those states. The goal of this issue is to add "roll up" view that shows only the _durations_ that the process was in each state. The original time history view will remain available as well.
